### PR TITLE
Add Attributes in Colorize Mask

### DIFF
--- a/source/kra/parser.d
+++ b/source/kra/parser.d
@@ -120,6 +120,15 @@ void importAttributes(ref KRA kra, ref DOMEntity!string layerEntity, ref Layer[]
         case "clonelayer":
             kra.layers ~= new CloneLayerUuid(attrs);
             break;
+        case "colorizemask":
+            auto colorizeMask = new ColorizeMask(attrs);
+
+            auto layerFile = kra.fileRef.directory[buildPathKRA(kra.name, "layers", fileName ~ ".colorizemask", "colorize-coloring")];
+            kra.fileRef.expand(layerFile);
+
+            if (parseLayerData(layerFile.expandedData.ptr, colorizeMask))
+                layers ~= colorizeMask;
+            break;
         default:
             break;
         }


### PR DESCRIPTION
This PR checks for Colorize Mask and adds its attributes as well as tile data.
Closes #7.